### PR TITLE
MKT-3690 remove link_permissions

### DIFF
--- a/create_link/backend/python/app/api.py
+++ b/create_link/backend/python/app/api.py
@@ -73,30 +73,6 @@ def new_link_session() -> NewLinkSessionResponse:
             link_tags=["examples:create_link"],
             redirect_uri=settings.frontend_oauth_redirect_uri,
             settings=moneykit.models.LinkSessionSettingOverrides(
-                link_permissions=moneykit.models.LinkPermissions(
-                    requested=[
-                        moneykit.models.RequestedLinkPermission(
-                            scope=moneykit.models.LinkPermissionScope.ACCOUNTS,
-                            reason="play with MoneyKit examples.",
-                            required=True,
-                        ),
-                        moneykit.models.RequestedLinkPermission(
-                            scope=moneykit.models.LinkPermissionScope.ACCOUNT_NUMBERS,
-                            reason="play with MoneyKit examples.",
-                            required=True,
-                        ),
-                        moneykit.models.RequestedLinkPermission(
-                            scope=moneykit.models.LinkPermissionScope.IDENTITY,
-                            reason="play with MoneyKit examples.",
-                            required=True,
-                        ),
-                        moneykit.models.RequestedLinkPermission(
-                            scope=moneykit.models.LinkPermissionScope.TRANSACTIONS,
-                            reason="play with MoneyKit examples.",
-                            required=True,
-                        ),
-                    ]
-                ),
                 products=moneykit.models.ProductsSettings(
                     account_numbers=moneykit.models.AccountNumbersProductSettings(
                         required=False,

--- a/create_link/backend/python_without_sdk/app/api.py
+++ b/create_link/backend/python_without_sdk/app/api.py
@@ -94,30 +94,6 @@ async def new_link_session() -> NewLinkSessionResponse:
             "link_tags": ["examples:create_link"],
             "redirect_uri": settings.frontend_oauth_redirect_uri,
             "settings": {
-                "link_permissions": {
-                    "requested": [
-                        {
-                            "scope": "accounts",
-                            "reason": "play with MoneyKit examples",
-                            "required": True,
-                        },
-                        {
-                            "scope": "account_numbers",
-                            "reason": "play with MoneyKit examples",
-                            "required": True,
-                        },
-                        {
-                            "scope": "identity",
-                            "reason": "play with MoneyKit examples",
-                            "required": True,
-                        },
-                        {
-                            "scope": "transactions",
-                            "reason": "play with MoneyKit examples",
-                            "required": True,
-                        },
-                    ]
-                },
                 "products": {
                     "account_numbers": {"required": False, "prefetch": True},
                     "identity": {"required": False, "prefetch": True},

--- a/create_link/backend/ruby/app.rb
+++ b/create_link/backend/ruby/app.rb
@@ -55,15 +55,6 @@ post '/linking/session' do
         link_tags: ['examples:create_link'],
         redirect_uri: ENV['FRONTEND_OAUTH_REDIRECT_URI'] || 'http://localhost:3000',
         settings: {
-          link_permissions: {
-            requested: [
-              { scope: 'accounts', reason: 'play with MoneyKit examples.', required: true },
-              { scope: 'account_numbers', reason: 'play with MoneyKit examples.', required: true },
-              { scope: 'identity', reason: 'play with MoneyKit examples.', required: true },
-              { scope: 'transactions', reason: 'play with MoneyKit examples.', required: true }
-
-            ]
-          },
           products: {
             account_numbers: {
               required: false,


### PR DESCRIPTION
Removing the now-deprecated `link_permissions` field from the link session request